### PR TITLE
increase perf on classify calls by precalculating the frequency table…

### DIFF
--- a/lib/bae/classifier.rb
+++ b/lib/bae/classifier.rb
@@ -13,6 +13,8 @@ module Bae
     end
 
     def finish_training!
+      @frequency_table_size = @frequency_table.keys.size
+
       calculate_likelihoods!
       calculate_priors!
     end
@@ -68,7 +70,7 @@ module Bae
       likelihoods = @likelihoods.dup
       posterior = {}
 
-      vocab_size = frequency_table.keys.size
+      vocab_size = @frequency_table_size
 
       label_index.each do |label, index|
         words.map do |word|
@@ -130,7 +132,7 @@ module Bae
     def calculate_likelihoods!
       @likelihoods = label_index.inject({}) do |accumulator, (label, index)|
         initial_likelihood = 1.0
-        vocab_size = frequency_table.keys.size
+        vocab_size = @frequency_table_size
 
         frequency_table.each do |feature, row|
           laplace_word_likelihood = (row[index] + 1.0).to_f / (label_instance_count[label] + vocab_size).to_f


### PR DESCRIPTION
… size after traning and after state load

after the state is loaded or the training done I don't believe we change the frequency table any longer; I did some benchmarks on a simple string "STARBUCKSIAN THING" off of the state we have in production; this patch moves the average classification time from 13ms => 1ms

@film42 